### PR TITLE
BMH-2869 Added Level2/3 helper methods for Worldpay sale purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -47,9 +47,11 @@ module ActiveMerchant #:nodoc:
             case payment_method.brand
             when 'visa'
               doc.salesTax(level_2_data[:sales_tax]) if level_2_data[:sales_tax]
+              doc.taxExempt(true) if level_2_data[:sales_tax] == 0
             when 'master'
               doc.customerReference(level_2_data[:customer_code]) if level_2_data[:customer_code]
               doc.salesTax(level_2_data[:total_tax_amount]) if level_2_data[:total_tax_amount]
+              doc.taxExempt(true) if level_2_data[:total_tax_amount] == 0
               doc.detailTax do
                 doc.taxIncludedInTotal(level_2_data[:tax_included_in_total]) if level_2_data[:tax_included_in_total]
                 doc.taxAmount(level_2_data[:tax_amount]) if level_2_data[:tax_amount]
@@ -91,6 +93,7 @@ module ActiveMerchant #:nodoc:
       def add_level_three_information_tags_master(doc, payment_method, level_3_data)
         doc.customerReference :customerReference, level_3_data[:customer_code] if level_3_data[:customer_code]
         doc.salesTax(level_3_data[:total_tax_amount]) if level_3_data[:total_tax_amount]
+        doc.taxExempt(true) if level_3_data[:total_tax_amount] == 0
         doc.detailTax do
           doc.taxIncludedInTotal(level_3_data[:tax_included_in_total]) if level_3_data[:tax_included_in_total]
           doc.taxAmount(level_3_data[:tax_amount]) if level_3_data[:tax_amount]
@@ -119,6 +122,7 @@ module ActiveMerchant #:nodoc:
             doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
             doc.itemDiscountAmount(line_item[:discount_per_line_item]) unless line_item[:discount_per_line_item] < 0
             doc.unitCost(line_item[:unit_cost]) unless line_item[:unit_cost] < 0
+            doc.lineItemTotal(line_item[:line_item_total]) if line_item[:line_item_total]
             doc.detailTax do
               doc.taxIncludedInTotal(line_item[:tax_included_in_total]) if line_item[:tax_included_in_total]
               doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -40,6 +40,96 @@ module ActiveMerchant #:nodoc:
         check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
       end
 
+      def add_level_two_data(doc, payment_method, options = {})
+        level_2_data = options[:level_2_data]
+        if level_2_data
+          doc.enhancedData do
+            case payment_method.brand
+            when 'visa'
+              doc.salesTax(level_2_data[:sales_tax]) if level_2_data[:sales_tax]
+            when 'master'
+              doc.customerReference(level_2_data[:customer_code]) if level_2_data[:customer_code]
+              doc.salesTax(level_2_data[:total_tax_amount]) if level_2_data[:total_tax_amount]
+              doc.detailTax do
+                doc.taxIncludedInTotal(level_2_data[:tax_included_in_total]) if level_2_data[:tax_included_in_total]
+                doc.taxAmount(level_2_data[:tax_amount]) if level_2_data[:tax_amount]
+                doc.cardAcceptorTaxId(level_2_data[:card_acceptor_tax_id]) if level_2_data[:card_acceptor_tax_id]
+              end
+            end
+          end
+        end
+      end
+
+      def add_level_three_data(doc, payment_method, options = {})
+        level_3_data = options[:level_3_data]
+        if level_3_data
+          doc.enhancedData do
+            case payment_method.brand
+            when 'visa'
+              add_level_three_information_tags_visa(doc, payment_method, level_3_data)
+            when 'master'
+              add_level_three_information_tags_master(doc, payment_method, level_3_data)
+            end
+          end
+        end
+      end
+
+      def add_level_three_information_tags_visa(doc, payment_method, level_3_data)
+        doc.discountAmount(level_3_data[:discount_amount]) if level_3_data[:discount_amount]
+        doc.shippingAmount(level_3_data[:shipping_amount]) if level_3_data[:shipping_amount]
+        doc.dutyAmount(level_3_data[:duty_amount]) if level_3_data[:duty_amount]
+        doc.detailTax do
+          doc.taxIncludedInTotal(level_3_data[:tax_included_in_total]) if level_3_data[:tax_included_in_total]
+          doc.taxAmount(level_3_data[:tax_amount]) if level_3_data[:tax_amount]
+          doc.taxRate(level_3_data[:tax_rate]) if level_3_data[:tax_rate]
+          doc.taxTypeIdentifier(level_3_data[:tax_type_identifier]) if level_3_data[:tax_type_identifier]
+          doc.cardAcceptorTaxId(level_3_data[:card_acceptor_tax_id]) if level_3_data[:card_acceptor_tax_id]
+        end
+        add_line_item_information_for_level_three_visa(doc, payment_method, level_3_data)
+      end
+
+      def add_level_three_information_tags_master(doc, payment_method, level_3_data)
+        doc.customerReference :customerReference, level_3_data[:customer_code] if level_3_data[:customer_code]
+        doc.salesTax(level_3_data[:total_tax_amount]) if level_3_data[:total_tax_amount]
+        doc.detailTax do
+          doc.taxIncludedInTotal(level_3_data[:tax_included_in_total]) if level_3_data[:tax_included_in_total]
+          doc.taxAmount(level_3_data[:tax_amount]) if level_3_data[:tax_amount]
+          doc.cardAcceptorTaxId :cardAcceptorTaxId, level_3_data[:card_acceptor_tax_id] if level_3_data[:card_acceptor_tax_id]
+        end
+        doc.lineItemData do
+          level_3_data[:line_items].each do |line_item|
+            doc.itemDescription(line_item[:item_description]) if line_item[:item_description]
+            doc.productCode(line_item[:product_code]) if line_item[:product_code]
+            doc.quantity(line_item[:quantity]) if line_item[:quantity]
+            doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
+            doc.lineItemTotal(line_item[:line_item_total]) if line_item[:line_item_total]
+          end
+        end
+      end
+
+      def add_line_item_information_for_level_three_visa(doc, payment_method, level_3_data)
+        doc.lineItemData do
+          level_3_data[:line_items].each do |line_item|
+            doc.itemSequenceNumber(line_item[:item_sequence_number]) if line_item[:item_sequence_number]
+            doc.commodityCode(line_item[:commodity_code]) if line_item[:commodity_code]
+            doc.itemDescription(line_item[:item_description]) if line_item[:item_description]
+            doc.productCode(line_item[:product_code]) if line_item[:product_code]
+            doc.quantity(line_item[:quantity]) if line_item[:quantity]
+            doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
+            doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
+            doc.itemDiscountAmount(line_item[:discount_per_line_item]) unless line_item[:discount_per_line_item] < 0
+            doc.unitCost(line_item[:unit_cost]) unless line_item[:unit_cost] < 0
+            doc.detailTax do
+              doc.taxIncludedInTotal(line_item[:tax_included_in_total]) if line_item[:tax_included_in_total]
+              doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
+              doc.taxRate(line_item[:tax_rate]) if line_item[:tax_rate]
+              doc.taxTypeIdentifier(line_item[:tax_type_identifier]) if line_item[:tax_type_identifier]
+              doc.cardAcceptorTaxId(line_item[:card_acceptor_tax_id]) if line_item[:card_acceptor_tax_id]
+            end
+          end
+        end
+      end
+
       def authorize(money, payment_method, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
@@ -228,6 +318,8 @@ module ActiveMerchant #:nodoc:
         add_descriptor(doc, options)
         add_processing_type(doc, options)
         add_original_network_transaction(doc, options)
+        add_level_two_data(doc, payment_method, options)
+        add_level_three_data(doc, payment_method, options)
         add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
         add_stored_credential_params(doc, options)

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = '1.125.0'
+  VERSION = '1.126.0'
 end


### PR DESCRIPTION
### Story Description
https://affinipay.atlassian.net/browse/BMH-2869

### Notes to Reviewer
Added Level2/Level3 helper methods to include enhancedData in gateway purchase request.
reference PR: https://github.com/activemerchant/active_merchant/commit/d368a7fb3ee30d6581b8369a515312caa31d71d5
Unit tests we added in the PR are based on the old test setup, in the future when performing gem upgrade, we can replace the unit test file completely and use their existing unit test setup.
### QA