### PR TITLE
BMH-2918 Added support for saved card payment_method brand and name for gateway purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 require 'active_merchant/billing/gateways/litle/paypage_registration'
+require 'active_merchant/billing/gateways/litle/token'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -114,15 +115,15 @@ module ActiveMerchant #:nodoc:
         doc.lineItemData do
           level_3_data[:line_items].each do |line_item|
             doc.itemSequenceNumber(line_item[:item_sequence_number]) if line_item[:item_sequence_number]
-            doc.commodityCode(line_item[:commodity_code]) if line_item[:commodity_code]
             doc.itemDescription(line_item[:item_description]) if line_item[:item_description]
             doc.productCode(line_item[:product_code]) if line_item[:product_code]
             doc.quantity(line_item[:quantity]) if line_item[:quantity]
             doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
             doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
-            doc.itemDiscountAmount(line_item[:discount_per_line_item]) unless line_item[:discount_per_line_item] < 0
-            doc.unitCost(line_item[:unit_cost]) unless line_item[:unit_cost] < 0
             doc.lineItemTotal(line_item[:line_item_total]) if line_item[:line_item_total]
+            doc.itemDiscountAmount(line_item[:discount_per_line_item]) if line_item[:discount_per_line_item]
+            doc.commodityCode(line_item[:commodity_code]) if line_item[:commodity_code]
+            doc.unitCost(line_item[:unit_cost]) if line_item[:unit_cost]
             doc.detailTax do
               doc.taxIncludedInTotal(line_item[:tax_included_in_total]) if line_item[:tax_included_in_total]
               doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
@@ -320,10 +321,10 @@ module ActiveMerchant #:nodoc:
         add_payment_method(doc, payment_method, options)
         add_pos(doc, payment_method)
         add_descriptor(doc, options)
-        add_processing_type(doc, options)
-        add_original_network_transaction(doc, options)
         add_level_two_data(doc, payment_method, options)
         add_level_three_data(doc, payment_method, options)
+        add_processing_type(doc, options)
+        add_original_network_transaction(doc, options)
         add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
         add_stored_credential_params(doc, options)

--- a/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
+++ b/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
@@ -13,7 +13,7 @@ module ActiveMerchant
     # The name parameter is allowed by Vantiv as a member of the billToAddress element.
     # It is passed in here to be consistent with the rest of the Litle gateway and Activemerchant.
     class LitlePaypageRegistration
-      attr_reader :paypage_registration_id, :month, :year, :verification_value, :name, :type
+      attr_reader :paypage_registration_id, :month, :year, :verification_value, :name, :type, :brand
 
       def initialize(paypage_registration_id, options = {})
         @paypage_registration_id = paypage_registration_id
@@ -22,6 +22,7 @@ module ActiveMerchant
         @verification_value = options[:verification_value]
         @name = options[:name]
         @type = options[:type]
+        @brand = options[:brand]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/litle/token.rb
+++ b/lib/active_merchant/billing/gateways/litle/token.rb
@@ -1,0 +1,15 @@
+module ActiveMerchant
+  module Billing
+    # The name parameter is allowed by Vantiv as a member of the billToAddress element.
+    # It is passed in here to be consistent with the rest of the Litle gateway and Activemerchant.
+    class LitleToken
+      attr_reader :litle_token, :name, :brand
+
+      def initialize(litle_token, options = {})
+        @litle_token = litle_token
+        @name = options[:name]
+        @brand = options[:brand]
+      end
+    end
+  end
+end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -264,7 +264,7 @@ class LitleTest < Test::Unit::TestCase
         discount_amount: 0,
         shipping_amount: 0,
         duty_amount: 0,
-        total_tax_amount: 0,
+        tax_amount: 0,
         line_items: [{
           item_sequence_number: 1,
           commodity_code: 'Comm',
@@ -293,6 +293,40 @@ class LitleTest < Test::Unit::TestCase
       assert_match(%r(<quantity>1</quantity>), data)
       assert_match(%r(<commodityCode>Comm</commodityCode>), data)
       assert_match(%r(<itemSequenceNumber>1</itemSequenceNumber>), data)
+      assert_match(%r(<taxAmount>0</taxAmount>), data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_with_litle_token_of_level_3_rates
+    litle_token = ActiveMerchant::Billing::LitleToken.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5T',
+      brand: 'visa',
+      name: 'Joe Payer'
+    )
+    options = @options.merge(
+      level_3_data: {
+        discount_amount: 0,
+        shipping_amount: 0,
+        duty_amount: 0,
+        tax_amount: 0,
+        line_items: [{
+          item_sequence_number: 1,
+          commodity_code: 'Comm',
+          product_code: 'test',
+          item_description: 'Legal services',
+          quantity: 1,
+          unit_of_measure: 'EA',
+          discount_per_line_item: 0,
+          unit_cost: 500,
+          line_item_total: 500
+        }]
+      }
+    )
+    stub_comms do
+      @gateway.purchase(@amount, litle_token, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<unitCost>500</unitCost>), data)
+      assert_match(%r(<taxAmount>0</taxAmount>), data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
### Story Description
https://affinipay.atlassian.net/browse/BMH-2918

### Notes to Reviewer

- Addition to https://github.com/mycase/active_merchant/pull/6, added support for transactions with saved cards.
- Added brand and name for saved_cards litle_token. 
- For card_entry transactions included payment_method brand. 

### QA