### PR TITLE
BMH-2926 Added expiration year and month to the LitleToken for expDate of enhancedData related to level3 rates

### DIFF
--- a/lib/active_merchant/billing/gateways/litle/token.rb
+++ b/lib/active_merchant/billing/gateways/litle/token.rb
@@ -3,10 +3,12 @@ module ActiveMerchant
     # The name parameter is allowed by Vantiv as a member of the billToAddress element.
     # It is passed in here to be consistent with the rest of the Litle gateway and Activemerchant.
     class LitleToken
-      attr_reader :litle_token, :name, :brand
+      attr_reader :litle_token, :name, :brand, :month, :year
 
       def initialize(litle_token, options = {})
         @litle_token = litle_token
+        @month = options[:month]
+        @year = options[:year]
         @name = options[:name]
         @brand = options[:brand]
       end

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = '1.127.0'
+  VERSION = '1.128.0'
 end


### PR DESCRIPTION
### Feature Ticket: [2926](https://affinipay.atlassian.net/browse/BMH-2926)

### Description
Included year, month of the saved_cards litle_token to the enhancedData for level 3 rates qualification
Similar to https://github.com/mycase/active_merchant/pull/9, updated the version from 1.127.0 to 1.128.0

### QA